### PR TITLE
Fix #1

### DIFF
--- a/src/lt/plugins/litex-viewer.cljs
+++ b/src/lt/plugins/litex-viewer.cljs
@@ -81,7 +81,7 @@
           :triggers #{:proc.out}
           :reaction (fn [this data]
                       (let [loc (into {} (remove nil? (map kwpair (.split (.toString data) "\n"))))
-                            filename (files/join (:cwd @this) (:Input loc))
+                            filename (:Input loc)
                             line (- (:Line loc) 1)
                             column (- (:Column loc) 1)]
                         (cmd/exec! :open-path filename)


### PR DESCRIPTION
In behavior on-out there is a line defining filename as

``` clojurescript
filename (files/join (:cwd @this) (:Input loc))
```

And obviously debug shows that `(:cwd @this)` is a working directory and `(:Input loc)` is a _full_ filename.
I've changed this to just

```
filename (:Input loc)
```

and it works for me.
