### PR TITLE
Checking settings file existence before attempting to read them

### DIFF
--- a/litex_compiled.js
+++ b/litex_compiled.js
@@ -18,10 +18,10 @@ goog.require('lt.objs.editor.pool');
 goog.require('lt.objs.command');
 goog.require('lt.objs.editor');
 lt.plugins.litex._exec = require("child_process").exec;
-lt.plugins.litex.exec = (function exec(command,cwd,encoding,exitfunc){return lt.plugins.litex._exec.call(null,command,(function (){var obj8201 = {"cwd":cwd,"encoding":encoding,"env":lt.objs.proc.merge_env.call(null,null),"maxBuffer":(1024 * 1024)};return obj8201;
+lt.plugins.litex.exec = (function exec(command,cwd,encoding,exitfunc){return lt.plugins.litex._exec.call(null,command,(function (){var obj6362 = {"cwd":cwd,"encoding":encoding,"env":lt.objs.proc.merge_env.call(null,null),"maxBuffer":(1024 * 1024)};return obj6362;
 })(),exitfunc);
 });
-lt.plugins.litex.kwpair = (function kwpair(str){var vec__8203 = str.split(":");var k = cljs.core.nth.call(null,vec__8203,0,null);var v = cljs.core.nth.call(null,vec__8203,1,null);if(cljs.core.truth_(v))
+lt.plugins.litex.kwpair = (function kwpair(str){var vec__6364 = str.split(":");var k = cljs.core.nth.call(null,vec__6364,0,null);var v = cljs.core.nth.call(null,vec__6364,1,null);if(cljs.core.truth_(v))
 {return new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [cljs.core.keyword.call(null,k),v], null);
 } else
 {return null;
@@ -37,39 +37,39 @@ lt.plugins.litex.ensure_absolute = (function ensure_absolute(path,dir){if(cljs.c
 * @param {...*} var_args
 */
 lt.plugins.litex.run_commands = (function() { 
-var run_commands__delegate = function (commands,cwd,exitfunc,p__8204){var map__8206 = p__8204;var map__8206__$1 = ((cljs.core.seq_QMARK_.call(null,map__8206))?cljs.core.apply.call(null,cljs.core.hash_map,map__8206):map__8206);var encoding = cljs.core.get.call(null,map__8206__$1,new cljs.core.Keyword(null,"encoding","encoding",2725126341),"utf8");var accout = cljs.core.get.call(null,map__8206__$1,new cljs.core.Keyword(null,"accout","accout",3885420191),"");if(cljs.core.empty_QMARK_.call(null,commands))
+var run_commands__delegate = function (commands,cwd,exitfunc,p__6365){var map__6367 = p__6365;var map__6367__$1 = ((cljs.core.seq_QMARK_.call(null,map__6367))?cljs.core.apply.call(null,cljs.core.hash_map,map__6367):map__6367);var encoding = cljs.core.get.call(null,map__6367__$1,new cljs.core.Keyword(null,"encoding","encoding",2725126341),"utf8");var accout = cljs.core.get.call(null,map__6367__$1,new cljs.core.Keyword(null,"accout","accout",3885420191),"");if(cljs.core.empty_QMARK_.call(null,commands))
 {return exitfunc.call(null,null,accout,"");
 } else
-{var command = cljs.core.first.call(null,commands);var commands__$1 = cljs.core.rest.call(null,commands);return lt.plugins.litex.exec.call(null,command,cwd,encoding,((function (command,commands__$1,map__8206,map__8206__$1,encoding,accout){
+{var command = cljs.core.first.call(null,commands);var commands__$1 = cljs.core.rest.call(null,commands);return lt.plugins.litex.exec.call(null,command,cwd,encoding,((function (command,commands__$1,map__6367,map__6367__$1,encoding,accout){
 return (function (error,stdout,stderr){var stdout__$1 = [cljs.core.str(accout),cljs.core.str(stdout)].join('');if(cljs.core.truth_(error))
 {return exitfunc.call(null,error,stdout__$1,stderr);
 } else
 {return run_commands.call(null,commands__$1,cwd,exitfunc,new cljs.core.Keyword(null,"accout","accout",3885420191),stdout__$1,new cljs.core.Keyword(null,"encoding","encoding",2725126341),encoding);
 }
-});})(command,commands__$1,map__8206,map__8206__$1,encoding,accout))
+});})(command,commands__$1,map__6367,map__6367__$1,encoding,accout))
 );
 }
 };
 var run_commands = function (commands,cwd,exitfunc,var_args){
-var p__8204 = null;if (arguments.length > 3) {
-  p__8204 = cljs.core.array_seq(Array.prototype.slice.call(arguments, 3),0);} 
-return run_commands__delegate.call(this,commands,cwd,exitfunc,p__8204);};
+var p__6365 = null;if (arguments.length > 3) {
+  p__6365 = cljs.core.array_seq(Array.prototype.slice.call(arguments, 3),0);} 
+return run_commands__delegate.call(this,commands,cwd,exitfunc,p__6365);};
 run_commands.cljs$lang$maxFixedArity = 3;
-run_commands.cljs$lang$applyTo = (function (arglist__8215){
-var commands = cljs.core.first(arglist__8215);
-arglist__8215 = cljs.core.next(arglist__8215);
-var cwd = cljs.core.first(arglist__8215);
-arglist__8215 = cljs.core.next(arglist__8215);
-var exitfunc = cljs.core.first(arglist__8215);
-var p__8204 = cljs.core.rest(arglist__8215);
-return run_commands__delegate(commands,cwd,exitfunc,p__8204);
+run_commands.cljs$lang$applyTo = (function (arglist__6386){
+var commands = cljs.core.first(arglist__6386);
+arglist__6386 = cljs.core.next(arglist__6386);
+var cwd = cljs.core.first(arglist__6386);
+arglist__6386 = cljs.core.next(arglist__6386);
+var exitfunc = cljs.core.first(arglist__6386);
+var p__6365 = cljs.core.rest(arglist__6386);
+return run_commands__delegate(commands,cwd,exitfunc,p__6365);
 });
 run_commands.cljs$core$IFn$_invoke$arity$variadic = run_commands__delegate;
 return run_commands;
 })()
 ;
-lt.plugins.litex.get_config_from_settings = (function get_config_from_settings(path,which){var settings = lt.plugins.litex.get_settings.call(null,which,lt.objs.files.parent.call(null,path));var fullfilename = lt.plugins.litex.ensure_absolute.call(null,(function (){var or__6368__auto__ = cljs.core.get.call(null,settings,"filename");if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+lt.plugins.litex.get_config_from_settings = (function get_config_from_settings(path,which){var settings = lt.plugins.litex.get_settings.call(null,which,lt.objs.files.parent.call(null,path));var fullfilename = lt.plugins.litex.ensure_absolute.call(null,(function (){var or__4884__auto__ = cljs.core.get.call(null,settings,"filename");if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
 {return path;
 }
@@ -80,14 +80,14 @@ lt.plugins.litex.get_config_from_settings = (function get_config_from_settings(p
 {return null;
 }
 } else
-{var filename = lt.objs.files.basename.call(null,fullfilename);var cwd = lt.objs.files.parent.call(null,fullfilename);var commands = settings.call(null,"commands");var commands__$1 = ((typeof commands === 'string')?(function (){var or__6368__auto__ = lt.plugins.litex.COMMANDS.call(null,commands);if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+{var filename = lt.objs.files.basename.call(null,fullfilename);var cwd = lt.objs.files.parent.call(null,fullfilename);var commands = settings.call(null,"commands");var commands__$1 = ((typeof commands === 'string')?(function (){var or__4884__auto__ = lt.plugins.litex.COMMANDS.call(null,commands);if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
 {throw [cljs.core.str("Unknown command: \""),cljs.core.str(commands),cljs.core.str("\".  "),cljs.core.str("Remember, a custom command should be a list of strings.")].join('');
 }
 })():commands);var pathmap = ((function (filename,cwd,commands,commands__$1,settings,fullfilename){
 return (function (s){return clojure.string.replace.call(null,s,/%[fpbde%]/,((function (filename,cwd,commands,commands__$1,settings,fullfilename){
-return (function (p1__8207_SHARP_){return cljs.core.keyword.call(null,p1__8207_SHARP_).call(null,new cljs.core.PersistentArrayMap(null, 6, [new cljs.core.Keyword(null,"%f","%f",1013905491),filename,new cljs.core.Keyword(null,"%p","%p",1013905501),fullfilename,new cljs.core.Keyword(null,"%b","%b",1013905487),lt.objs.files.without_ext.call(null,filename),new cljs.core.Keyword(null,"%d","%d",1013905489),cwd,new cljs.core.Keyword(null,"%e","%e",1013905490),lt.objs.files.ext.call(null,filename),new cljs.core.Keyword(null,"%%","%%",1013905426),"%"], null));
+return (function (p1__6368_SHARP_){return cljs.core.keyword.call(null,p1__6368_SHARP_).call(null,new cljs.core.PersistentArrayMap(null, 6, [new cljs.core.Keyword(null,"%f","%f",1013905491),filename,new cljs.core.Keyword(null,"%p","%p",1013905501),fullfilename,new cljs.core.Keyword(null,"%b","%b",1013905487),lt.objs.files.without_ext.call(null,filename),new cljs.core.Keyword(null,"%d","%d",1013905489),cwd,new cljs.core.Keyword(null,"%e","%e",1013905490),lt.objs.files.ext.call(null,filename),new cljs.core.Keyword(null,"%%","%%",1013905426),"%"], null));
 });})(filename,cwd,commands,commands__$1,settings,fullfilename))
 );
 });})(filename,cwd,commands,commands__$1,settings,fullfilename))
@@ -116,13 +116,14 @@ lt.plugins.litex.run_commands_to_console = (function run_commands_to_console(con
 });lt.object.merge_BANG_.call(null,editor,new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"pdfname","pdfname",4590556655),pdfname], null));
 return lt.plugins.litex.run_commands.call(null,commands,cwd,exitfunc);
 });
-lt.plugins.litex.load_settings = (function load_settings(path){var file = lt.objs.files.open_sync.call(null,path);var content = new cljs.core.Keyword(null,"content","content",1965434859).cljs$core$IFn$_invoke$arity$1(file);if(cljs.core.truth_(content))
+lt.plugins.litex.load_settings = (function load_settings(path){if(cljs.core.truth_(lt.objs.files.file_QMARK_.call(null,path)))
+{var file = lt.objs.files.open_sync.call(null,path);var content = new cljs.core.Keyword(null,"content","content",1965434859).cljs$core$IFn$_invoke$arity$1(file);if(cljs.core.truth_(content))
 {try{return cljs.core.js__GT_clj.call(null,JSON.parse(content.replace((new RegExp("^\\s*//.*$","gm")),"")));
-}catch (e8209){if((e8209 instanceof Error))
-{var e = e8209;return console.log([cljs.core.str("Error parsing "),cljs.core.str(path),cljs.core.str(":\n  "),cljs.core.str(e),cljs.core.str("\nIgnoring this file.")].join(''));
+}catch (e6370){if((e6370 instanceof Error))
+{var e = e6370;return console.log([cljs.core.str("Error parsing "),cljs.core.str(path),cljs.core.str(":\n  "),cljs.core.str(e),cljs.core.str("\nIgnoring this file.")].join(''));
 } else
 {if(new cljs.core.Keyword(null,"else","else",1017020587))
-{throw e8209;
+{throw e6370;
 } else
 {return null;
 }
@@ -130,12 +131,15 @@ lt.plugins.litex.load_settings = (function load_settings(path){var file = lt.obj
 }} else
 {return null;
 }
+} else
+{return null;
+}
 });
 lt.plugins.litex.global_settings = (function global_settings(){return lt.objs.files.join.call(null,lt.objs.files.parent.call(null,lt.objs.files.data_path),"litexrc");
 });
 lt.plugins.litex.local_settings = (function local_settings(cwd){return lt.objs.files.join.call(null,cwd,".litexrc");
 });
-lt.plugins.litex.get_settings = (function get_settings(which,cwd){return cljs.core.apply.call(null,cljs.core.merge,cljs.core.map.call(null,(function (p1__8210_SHARP_){return cljs.core.get.call(null,p1__8210_SHARP_,which);
+lt.plugins.litex.get_settings = (function get_settings(which,cwd){return cljs.core.apply.call(null,cljs.core.merge,cljs.core.map.call(null,(function (p1__6371_SHARP_){return cljs.core.get.call(null,p1__6371_SHARP_,which);
 }),new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [lt.plugins.litex.DEFAULT_SETTINGS,lt.plugins.litex.load_settings.call(null,lt.plugins.litex.global_settings.call(null)),lt.plugins.litex.load_settings.call(null,lt.plugins.litex.local_settings.call(null,cwd))], null)));
 });
 lt.plugins.litex.get_viewer_command = (function get_viewer_command(cwd){return cljs.core.some.call(null,cljs.core.identity,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [cljs.core.get.call(null,lt.plugins.litex.load_settings.call(null,lt.plugins.litex.local_settings.call(null,cwd)),"PDF-viewer"),cljs.core.get.call(null,lt.plugins.litex.load_settings.call(null,lt.plugins.litex.global_settings.call(null)),"PDF-viewer"),"internal"], null));
@@ -152,7 +156,7 @@ return lt.object.raise.call(null,lt.plugins.litex.tex_lang,new cljs.core.Keyword
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex","on-eval.one","lt.plugins.litex/on-eval.one",1793048927),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.__BEH__on_eval__DOT__one,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"eval.one","eval.one",1173589382),null], null), null));
 lt.plugins.litex.__BEH__eval_BANG_ = (function __BEH__eval_BANG_(this$,which,editor){var temp__4092__auto__ = lt.plugins.litex.get_config_from_settings.call(null,new cljs.core.Keyword(null,"path","path",1017337751).cljs$core$IFn$_invoke$arity$1(new cljs.core.Keyword(null,"info","info",1017141280).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,editor))),which);if(cljs.core.truth_(temp__4092__auto__))
-{var map__8212 = temp__4092__auto__;var map__8212__$1 = ((cljs.core.seq_QMARK_.call(null,map__8212))?cljs.core.apply.call(null,cljs.core.hash_map,map__8212):map__8212);var pdfname = cljs.core.get.call(null,map__8212__$1,new cljs.core.Keyword(null,"pdfname","pdfname",4590556655));var texname = cljs.core.get.call(null,map__8212__$1,new cljs.core.Keyword(null,"texname","texname",3890856612));var cwd = cljs.core.get.call(null,map__8212__$1,new cljs.core.Keyword(null,"cwd","cwd",1014003170));var commands = cljs.core.get.call(null,map__8212__$1,new cljs.core.Keyword(null,"commands","commands",4706336250));lt.object.merge_BANG_.call(null,lt.plugins.litex.tex_lang,new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"last-tex-file","last-tex-file",710788139),texname], null));
+{var map__6373 = temp__4092__auto__;var map__6373__$1 = ((cljs.core.seq_QMARK_.call(null,map__6373))?cljs.core.apply.call(null,cljs.core.hash_map,map__6373):map__6373);var pdfname = cljs.core.get.call(null,map__6373__$1,new cljs.core.Keyword(null,"pdfname","pdfname",4590556655));var texname = cljs.core.get.call(null,map__6373__$1,new cljs.core.Keyword(null,"texname","texname",3890856612));var cwd = cljs.core.get.call(null,map__6373__$1,new cljs.core.Keyword(null,"cwd","cwd",1014003170));var commands = cljs.core.get.call(null,map__6373__$1,new cljs.core.Keyword(null,"commands","commands",4706336250));lt.object.merge_BANG_.call(null,lt.plugins.litex.tex_lang,new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"last-tex-file","last-tex-file",710788139),texname], null));
 var runner = ((cljs.core._EQ_.call(null,lt.plugins.litex.get_viewer_command.call(null,cwd),"internal"))?lt.plugins.litex.run_commands_to_client:lt.plugins.litex.run_commands_to_console);return runner.call(null,new cljs.core.Keyword(null,"editor.eval.tex","editor.eval.tex",1083030184),editor,commands,cwd,pdfname,false);
 } else
 {return null;
@@ -160,7 +164,7 @@ var runner = ((cljs.core._EQ_.call(null,lt.plugins.litex.get_viewer_command.call
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex","eval!","lt.plugins.litex/eval!",4032952478),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.__BEH__eval_BANG_,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"eval!","eval!",1110791799),null], null), null));
 lt.plugins.litex.__BEH__sync_forward = (function __BEH__sync_forward(editor){var pos = lt.objs.editor.__GT_cursor.call(null,editor);var path = new cljs.core.Keyword(null,"path","path",1017337751).cljs$core$IFn$_invoke$arity$1(new cljs.core.Keyword(null,"info","info",1017141280).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,editor)));var filename = lt.objs.files.basename.call(null,path);var cwd = lt.objs.files.parent.call(null,path);var pdfname = cljs.core.some.call(null,((function (pos,path,filename,cwd){
-return (function (p1__8213_SHARP_){var name = new cljs.core.Keyword(null,"pdfname","pdfname",4590556655).cljs$core$IFn$_invoke$arity$1(p1__8213_SHARP_.call(null));if(cljs.core.truth_(lt.objs.files.exists_QMARK_.call(null,name)))
+return (function (p1__6374_SHARP_){var name = new cljs.core.Keyword(null,"pdfname","pdfname",4590556655).cljs$core$IFn$_invoke$arity$1(p1__6374_SHARP_.call(null));if(cljs.core.truth_(lt.objs.files.exists_QMARK_.call(null,name)))
 {return name;
 } else
 {return null;
@@ -177,7 +181,7 @@ return (function (){return lt.plugins.litex.get_config_from_settings.call(null,n
 });})(pos,path,filename,cwd))
 ], null));if(cljs.core.truth_(pdfname))
 {var sync_command = lt.plugins.litex.get_viewer_command.call(null,cwd);var runner = ((cljs.core._EQ_.call(null,sync_command,"internal"))?lt.plugins.litex.run_commands_to_client:lt.plugins.litex.run_commands_to_console);var sync_command__$1 = ((cljs.core._EQ_.call(null,sync_command,"internal"))?"synctex view -i \"%l:%c:%p\" -o \"%o\"":sync_command);var sync_command__$2 = clojure.string.replace.call(null,sync_command__$1,/%[fpbdeolc%]/,((function (sync_command,runner,sync_command__$1,pos,path,filename,cwd,pdfname){
-return (function (p1__8214_SHARP_){return cljs.core.keyword.call(null,p1__8214_SHARP_).call(null,cljs.core.PersistentHashMap.fromArrays([new cljs.core.Keyword(null,"%b","%b",1013905487),new cljs.core.Keyword(null,"%c","%c",1013905488),new cljs.core.Keyword(null,"%d","%d",1013905489),new cljs.core.Keyword(null,"%f","%f",1013905491),new cljs.core.Keyword(null,"%e","%e",1013905490),new cljs.core.Keyword(null,"%l","%l",1013905497),new cljs.core.Keyword(null,"%p","%p",1013905501),new cljs.core.Keyword(null,"%o","%o",1013905500),new cljs.core.Keyword(null,"%%","%%",1013905426)],[lt.objs.files.without_ext.call(null,filename),(1 + new cljs.core.Keyword(null,"ch","ch",1013907415).cljs$core$IFn$_invoke$arity$1(pos)),cwd,filename,lt.objs.files.ext.call(null,filename),(1 + new cljs.core.Keyword(null,"line","line",1017226086).cljs$core$IFn$_invoke$arity$1(pos)),path,pdfname,"%"]));
+return (function (p1__6375_SHARP_){return cljs.core.keyword.call(null,p1__6375_SHARP_).call(null,cljs.core.PersistentHashMap.fromArrays([new cljs.core.Keyword(null,"%b","%b",1013905487),new cljs.core.Keyword(null,"%c","%c",1013905488),new cljs.core.Keyword(null,"%d","%d",1013905489),new cljs.core.Keyword(null,"%f","%f",1013905491),new cljs.core.Keyword(null,"%e","%e",1013905490),new cljs.core.Keyword(null,"%l","%l",1013905497),new cljs.core.Keyword(null,"%p","%p",1013905501),new cljs.core.Keyword(null,"%o","%o",1013905500),new cljs.core.Keyword(null,"%%","%%",1013905426)],[lt.objs.files.without_ext.call(null,filename),(1 + new cljs.core.Keyword(null,"ch","ch",1013907415).cljs$core$IFn$_invoke$arity$1(pos)),cwd,filename,lt.objs.files.ext.call(null,filename),(1 + new cljs.core.Keyword(null,"line","line",1017226086).cljs$core$IFn$_invoke$arity$1(pos)),path,pdfname,"%"]));
 });})(sync_command,runner,sync_command__$1,pos,path,filename,cwd,pdfname))
 );return runner.call(null,new cljs.core.Keyword(null,"litex.forward-sync","litex.forward-sync",2440308217),editor,new cljs.core.PersistentVector(null, 1, 5, cljs.core.PersistentVector.EMPTY_NODE, [sync_command__$2], null),lt.objs.files.parent.call(null,pdfname),pdfname,true);
 } else
@@ -188,7 +192,7 @@ lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex","syn
 lt.plugins.litex.__BEH__sync_backward = (function __BEH__sync_backward(this$,cwd,pdfname,pagenum,clickX,clickY){return lt.plugins.litex.run_commands.call(null,new cljs.core.PersistentVector(null, 1, 5, cljs.core.PersistentVector.EMPTY_NODE, [[cljs.core.str("synctex edit -o \""),cljs.core.str(pagenum),cljs.core.str(":"),cljs.core.str(clickX),cljs.core.str(":"),cljs.core.str(clickY),cljs.core.str(":"),cljs.core.str(pdfname),cljs.core.str("\"")].join('')], null),cwd,(function (error,stdout,stderr){if(cljs.core.not.call(null,error))
 {var loc = cljs.core.into.call(null,cljs.core.PersistentArrayMap.EMPTY,cljs.core.remove.call(null,cljs.core.nil_QMARK_,cljs.core.map.call(null,lt.plugins.litex.kwpair,stdout.split("\n"))));var filename = lt.objs.files.resolve.call(null,cwd,new cljs.core.Keyword(null,"Input","Input",1084709660).cljs$core$IFn$_invoke$arity$1(loc));var line = (new cljs.core.Keyword(null,"Line","Line",1016272774).cljs$core$IFn$_invoke$arity$1(loc) - 1);var column = (new cljs.core.Keyword(null,"Column","Column",3037901544).cljs$core$IFn$_invoke$arity$1(loc) - 1);lt.objs.command.exec_BANG_.call(null,new cljs.core.Keyword(null,"open-path","open-path",2513940794),filename);
 var temp__4090__auto__ = cljs.core.first.call(null,lt.objs.editor.pool.by_path.call(null,filename));if(cljs.core.truth_(temp__4090__auto__))
-{var edit = temp__4090__auto__;lt.objs.editor.move_cursor.call(null,edit,new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"line","line",1017226086),line,new cljs.core.Keyword(null,"ch","ch",1013907415),(function (){var x__6675__auto__ = column;var y__6676__auto__ = 0;return ((x__6675__auto__ > y__6676__auto__) ? x__6675__auto__ : y__6676__auto__);
+{var edit = temp__4090__auto__;lt.objs.editor.move_cursor.call(null,edit,new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"line","line",1017226086),line,new cljs.core.Keyword(null,"ch","ch",1013907415),(function (){var x__5191__auto__ = column;var y__5192__auto__ = 0;return ((x__5191__auto__ > y__5192__auto__) ? x__5191__auto__ : y__5192__auto__);
 })()], null));
 return lt.objs.editor.center_cursor.call(null,edit);
 } else
@@ -330,53 +334,53 @@ goog.require('lt.objs.tabs');
 goog.require('lt.objs.clients');
 goog.require('lt.objs.editor.pool');
 goog.require('lt.objs.command');
-lt.plugins.litex.viewer.utils = (function (){var obj7899 = {};return obj7899;
+lt.plugins.litex.viewer.utils = (function (){var obj6398 = {};return obj6398;
 })();
 lttools = lt.plugins.litex.viewer.utils;
 lt.plugins.litex.viewer.add_util = (function add_util(nme,fn){return (lt.plugins.litex.viewer.utils[cljs.core.name.call(null,nme)] = fn);
 });
-lt.plugins.litex.viewer.zoom_in = (function zoom_in(this$){var e__7759__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"zoom-in"], null),"\u2295"], null));var seq__7906_8001 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__7759__auto__){
+lt.plugins.litex.viewer.zoom_in = (function zoom_in(this$){var e__6275__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"zoom-in"], null),"\u2295"], null));var seq__6405_6500 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__6275__auto__){
 return (function (){return lt.object.raise.call(null,this$,new cljs.core.Keyword(null,"zoom-in!","zoom-in!",1897005588));
-});})(e__7759__auto__))
-], null)));var chunk__7907_8002 = null;var count__7908_8003 = 0;var i__7909_8004 = 0;while(true){
-if((i__7909_8004 < count__7908_8003))
-{var vec__7910_8005 = cljs.core._nth.call(null,chunk__7907_8002,i__7909_8004);var ev__7760__auto___8006 = cljs.core.nth.call(null,vec__7910_8005,0,null);var func__7761__auto___8007 = cljs.core.nth.call(null,vec__7910_8005,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8006,func__7761__auto___8007);
+});})(e__6275__auto__))
+], null)));var chunk__6406_6501 = null;var count__6407_6502 = 0;var i__6408_6503 = 0;while(true){
+if((i__6408_6503 < count__6407_6502))
+{var vec__6409_6504 = cljs.core._nth.call(null,chunk__6406_6501,i__6408_6503);var ev__6276__auto___6505 = cljs.core.nth.call(null,vec__6409_6504,0,null);var func__6277__auto___6506 = cljs.core.nth.call(null,vec__6409_6504,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6505,func__6277__auto___6506);
 {
-var G__8008 = seq__7906_8001;
-var G__8009 = chunk__7907_8002;
-var G__8010 = count__7908_8003;
-var G__8011 = (i__7909_8004 + 1);
-seq__7906_8001 = G__8008;
-chunk__7907_8002 = G__8009;
-count__7908_8003 = G__8010;
-i__7909_8004 = G__8011;
+var G__6507 = seq__6405_6500;
+var G__6508 = chunk__6406_6501;
+var G__6509 = count__6407_6502;
+var G__6510 = (i__6408_6503 + 1);
+seq__6405_6500 = G__6507;
+chunk__6406_6501 = G__6508;
+count__6407_6502 = G__6509;
+i__6408_6503 = G__6510;
 continue;
 }
 } else
-{var temp__4092__auto___8012 = cljs.core.seq.call(null,seq__7906_8001);if(temp__4092__auto___8012)
-{var seq__7906_8013__$1 = temp__4092__auto___8012;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7906_8013__$1))
-{var c__7116__auto___8014 = cljs.core.chunk_first.call(null,seq__7906_8013__$1);{
-var G__8015 = cljs.core.chunk_rest.call(null,seq__7906_8013__$1);
-var G__8016 = c__7116__auto___8014;
-var G__8017 = cljs.core.count.call(null,c__7116__auto___8014);
-var G__8018 = 0;
-seq__7906_8001 = G__8015;
-chunk__7907_8002 = G__8016;
-count__7908_8003 = G__8017;
-i__7909_8004 = G__8018;
+{var temp__4092__auto___6511 = cljs.core.seq.call(null,seq__6405_6500);if(temp__4092__auto___6511)
+{var seq__6405_6512__$1 = temp__4092__auto___6511;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6405_6512__$1))
+{var c__5632__auto___6513 = cljs.core.chunk_first.call(null,seq__6405_6512__$1);{
+var G__6514 = cljs.core.chunk_rest.call(null,seq__6405_6512__$1);
+var G__6515 = c__5632__auto___6513;
+var G__6516 = cljs.core.count.call(null,c__5632__auto___6513);
+var G__6517 = 0;
+seq__6405_6500 = G__6514;
+chunk__6406_6501 = G__6515;
+count__6407_6502 = G__6516;
+i__6408_6503 = G__6517;
 continue;
 }
 } else
-{var vec__7911_8019 = cljs.core.first.call(null,seq__7906_8013__$1);var ev__7760__auto___8020 = cljs.core.nth.call(null,vec__7911_8019,0,null);var func__7761__auto___8021 = cljs.core.nth.call(null,vec__7911_8019,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8020,func__7761__auto___8021);
+{var vec__6410_6518 = cljs.core.first.call(null,seq__6405_6512__$1);var ev__6276__auto___6519 = cljs.core.nth.call(null,vec__6410_6518,0,null);var func__6277__auto___6520 = cljs.core.nth.call(null,vec__6410_6518,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6519,func__6277__auto___6520);
 {
-var G__8022 = cljs.core.next.call(null,seq__7906_8013__$1);
-var G__8023 = null;
-var G__8024 = 0;
-var G__8025 = 0;
-seq__7906_8001 = G__8022;
-chunk__7907_8002 = G__8023;
-count__7908_8003 = G__8024;
-i__7909_8004 = G__8025;
+var G__6521 = cljs.core.next.call(null,seq__6405_6512__$1);
+var G__6522 = null;
+var G__6523 = 0;
+var G__6524 = 0;
+seq__6405_6500 = G__6521;
+chunk__6406_6501 = G__6522;
+count__6407_6502 = G__6523;
+i__6408_6503 = G__6524;
 continue;
 }
 }
@@ -385,50 +389,50 @@ continue;
 }
 break;
 }
-return e__7759__auto__;
+return e__6275__auto__;
 });
-lt.plugins.litex.viewer.zoom_out = (function zoom_out(this$){var e__7759__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"zoom-out"], null),"\u2296"], null));var seq__7918_8026 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__7759__auto__){
+lt.plugins.litex.viewer.zoom_out = (function zoom_out(this$){var e__6275__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"zoom-out"], null),"\u2296"], null));var seq__6417_6525 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__6275__auto__){
 return (function (){return lt.object.raise.call(null,this$,new cljs.core.Keyword(null,"zoom-out!","zoom-out!",2620430271));
-});})(e__7759__auto__))
-], null)));var chunk__7919_8027 = null;var count__7920_8028 = 0;var i__7921_8029 = 0;while(true){
-if((i__7921_8029 < count__7920_8028))
-{var vec__7922_8030 = cljs.core._nth.call(null,chunk__7919_8027,i__7921_8029);var ev__7760__auto___8031 = cljs.core.nth.call(null,vec__7922_8030,0,null);var func__7761__auto___8032 = cljs.core.nth.call(null,vec__7922_8030,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8031,func__7761__auto___8032);
+});})(e__6275__auto__))
+], null)));var chunk__6418_6526 = null;var count__6419_6527 = 0;var i__6420_6528 = 0;while(true){
+if((i__6420_6528 < count__6419_6527))
+{var vec__6421_6529 = cljs.core._nth.call(null,chunk__6418_6526,i__6420_6528);var ev__6276__auto___6530 = cljs.core.nth.call(null,vec__6421_6529,0,null);var func__6277__auto___6531 = cljs.core.nth.call(null,vec__6421_6529,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6530,func__6277__auto___6531);
 {
-var G__8033 = seq__7918_8026;
-var G__8034 = chunk__7919_8027;
-var G__8035 = count__7920_8028;
-var G__8036 = (i__7921_8029 + 1);
-seq__7918_8026 = G__8033;
-chunk__7919_8027 = G__8034;
-count__7920_8028 = G__8035;
-i__7921_8029 = G__8036;
+var G__6532 = seq__6417_6525;
+var G__6533 = chunk__6418_6526;
+var G__6534 = count__6419_6527;
+var G__6535 = (i__6420_6528 + 1);
+seq__6417_6525 = G__6532;
+chunk__6418_6526 = G__6533;
+count__6419_6527 = G__6534;
+i__6420_6528 = G__6535;
 continue;
 }
 } else
-{var temp__4092__auto___8037 = cljs.core.seq.call(null,seq__7918_8026);if(temp__4092__auto___8037)
-{var seq__7918_8038__$1 = temp__4092__auto___8037;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7918_8038__$1))
-{var c__7116__auto___8039 = cljs.core.chunk_first.call(null,seq__7918_8038__$1);{
-var G__8040 = cljs.core.chunk_rest.call(null,seq__7918_8038__$1);
-var G__8041 = c__7116__auto___8039;
-var G__8042 = cljs.core.count.call(null,c__7116__auto___8039);
-var G__8043 = 0;
-seq__7918_8026 = G__8040;
-chunk__7919_8027 = G__8041;
-count__7920_8028 = G__8042;
-i__7921_8029 = G__8043;
+{var temp__4092__auto___6536 = cljs.core.seq.call(null,seq__6417_6525);if(temp__4092__auto___6536)
+{var seq__6417_6537__$1 = temp__4092__auto___6536;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6417_6537__$1))
+{var c__5632__auto___6538 = cljs.core.chunk_first.call(null,seq__6417_6537__$1);{
+var G__6539 = cljs.core.chunk_rest.call(null,seq__6417_6537__$1);
+var G__6540 = c__5632__auto___6538;
+var G__6541 = cljs.core.count.call(null,c__5632__auto___6538);
+var G__6542 = 0;
+seq__6417_6525 = G__6539;
+chunk__6418_6526 = G__6540;
+count__6419_6527 = G__6541;
+i__6420_6528 = G__6542;
 continue;
 }
 } else
-{var vec__7923_8044 = cljs.core.first.call(null,seq__7918_8038__$1);var ev__7760__auto___8045 = cljs.core.nth.call(null,vec__7923_8044,0,null);var func__7761__auto___8046 = cljs.core.nth.call(null,vec__7923_8044,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8045,func__7761__auto___8046);
+{var vec__6422_6543 = cljs.core.first.call(null,seq__6417_6537__$1);var ev__6276__auto___6544 = cljs.core.nth.call(null,vec__6422_6543,0,null);var func__6277__auto___6545 = cljs.core.nth.call(null,vec__6422_6543,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6544,func__6277__auto___6545);
 {
-var G__8047 = cljs.core.next.call(null,seq__7918_8038__$1);
-var G__8048 = null;
-var G__8049 = 0;
-var G__8050 = 0;
-seq__7918_8026 = G__8047;
-chunk__7919_8027 = G__8048;
-count__7920_8028 = G__8049;
-i__7921_8029 = G__8050;
+var G__6546 = cljs.core.next.call(null,seq__6417_6537__$1);
+var G__6547 = null;
+var G__6548 = 0;
+var G__6549 = 0;
+seq__6417_6525 = G__6546;
+chunk__6418_6526 = G__6547;
+count__6419_6527 = G__6548;
+i__6420_6528 = G__6549;
 continue;
 }
 }
@@ -437,50 +441,50 @@ continue;
 }
 break;
 }
-return e__7759__auto__;
+return e__6275__auto__;
 });
-lt.plugins.litex.viewer.show_log = (function show_log(this$){var e__7759__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"show-log"], null),"Show logs"], null));var seq__7930_8051 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__7759__auto__){
+lt.plugins.litex.viewer.show_log = (function show_log(this$){var e__6275__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"show-log"], null),"Show logs"], null));var seq__6429_6550 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__6275__auto__){
 return (function (){return lt.object.raise.call(null,this$,new cljs.core.Keyword(null,"show-log!","show-log!",3359135135));
-});})(e__7759__auto__))
-], null)));var chunk__7931_8052 = null;var count__7932_8053 = 0;var i__7933_8054 = 0;while(true){
-if((i__7933_8054 < count__7932_8053))
-{var vec__7934_8055 = cljs.core._nth.call(null,chunk__7931_8052,i__7933_8054);var ev__7760__auto___8056 = cljs.core.nth.call(null,vec__7934_8055,0,null);var func__7761__auto___8057 = cljs.core.nth.call(null,vec__7934_8055,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8056,func__7761__auto___8057);
+});})(e__6275__auto__))
+], null)));var chunk__6430_6551 = null;var count__6431_6552 = 0;var i__6432_6553 = 0;while(true){
+if((i__6432_6553 < count__6431_6552))
+{var vec__6433_6554 = cljs.core._nth.call(null,chunk__6430_6551,i__6432_6553);var ev__6276__auto___6555 = cljs.core.nth.call(null,vec__6433_6554,0,null);var func__6277__auto___6556 = cljs.core.nth.call(null,vec__6433_6554,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6555,func__6277__auto___6556);
 {
-var G__8058 = seq__7930_8051;
-var G__8059 = chunk__7931_8052;
-var G__8060 = count__7932_8053;
-var G__8061 = (i__7933_8054 + 1);
-seq__7930_8051 = G__8058;
-chunk__7931_8052 = G__8059;
-count__7932_8053 = G__8060;
-i__7933_8054 = G__8061;
+var G__6557 = seq__6429_6550;
+var G__6558 = chunk__6430_6551;
+var G__6559 = count__6431_6552;
+var G__6560 = (i__6432_6553 + 1);
+seq__6429_6550 = G__6557;
+chunk__6430_6551 = G__6558;
+count__6431_6552 = G__6559;
+i__6432_6553 = G__6560;
 continue;
 }
 } else
-{var temp__4092__auto___8062 = cljs.core.seq.call(null,seq__7930_8051);if(temp__4092__auto___8062)
-{var seq__7930_8063__$1 = temp__4092__auto___8062;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7930_8063__$1))
-{var c__7116__auto___8064 = cljs.core.chunk_first.call(null,seq__7930_8063__$1);{
-var G__8065 = cljs.core.chunk_rest.call(null,seq__7930_8063__$1);
-var G__8066 = c__7116__auto___8064;
-var G__8067 = cljs.core.count.call(null,c__7116__auto___8064);
-var G__8068 = 0;
-seq__7930_8051 = G__8065;
-chunk__7931_8052 = G__8066;
-count__7932_8053 = G__8067;
-i__7933_8054 = G__8068;
+{var temp__4092__auto___6561 = cljs.core.seq.call(null,seq__6429_6550);if(temp__4092__auto___6561)
+{var seq__6429_6562__$1 = temp__4092__auto___6561;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6429_6562__$1))
+{var c__5632__auto___6563 = cljs.core.chunk_first.call(null,seq__6429_6562__$1);{
+var G__6564 = cljs.core.chunk_rest.call(null,seq__6429_6562__$1);
+var G__6565 = c__5632__auto___6563;
+var G__6566 = cljs.core.count.call(null,c__5632__auto___6563);
+var G__6567 = 0;
+seq__6429_6550 = G__6564;
+chunk__6430_6551 = G__6565;
+count__6431_6552 = G__6566;
+i__6432_6553 = G__6567;
 continue;
 }
 } else
-{var vec__7935_8069 = cljs.core.first.call(null,seq__7930_8063__$1);var ev__7760__auto___8070 = cljs.core.nth.call(null,vec__7935_8069,0,null);var func__7761__auto___8071 = cljs.core.nth.call(null,vec__7935_8069,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8070,func__7761__auto___8071);
+{var vec__6434_6568 = cljs.core.first.call(null,seq__6429_6562__$1);var ev__6276__auto___6569 = cljs.core.nth.call(null,vec__6434_6568,0,null);var func__6277__auto___6570 = cljs.core.nth.call(null,vec__6434_6568,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6569,func__6277__auto___6570);
 {
-var G__8072 = cljs.core.next.call(null,seq__7930_8063__$1);
-var G__8073 = null;
-var G__8074 = 0;
-var G__8075 = 0;
-seq__7930_8051 = G__8072;
-chunk__7931_8052 = G__8073;
-count__7932_8053 = G__8074;
-i__7933_8054 = G__8075;
+var G__6571 = cljs.core.next.call(null,seq__6429_6562__$1);
+var G__6572 = null;
+var G__6573 = 0;
+var G__6574 = 0;
+seq__6429_6550 = G__6571;
+chunk__6430_6551 = G__6572;
+count__6431_6552 = G__6573;
+i__6432_6553 = G__6574;
 continue;
 }
 }
@@ -489,50 +493,50 @@ continue;
 }
 break;
 }
-return e__7759__auto__;
+return e__6275__auto__;
 });
-lt.plugins.litex.viewer.hide_log = (function hide_log(this$){var e__7759__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"hide-log"], null),"Hide logs"], null));var seq__7942_8076 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__7759__auto__){
+lt.plugins.litex.viewer.hide_log = (function hide_log(this$){var e__6275__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 3, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"button","button",3931183780),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"value","value",1125876963),"hide-log"], null),"Hide logs"], null));var seq__6441_6575 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__6275__auto__){
 return (function (){return lt.object.raise.call(null,this$,new cljs.core.Keyword(null,"hide-log!","hide-log!",1821177466));
-});})(e__7759__auto__))
-], null)));var chunk__7943_8077 = null;var count__7944_8078 = 0;var i__7945_8079 = 0;while(true){
-if((i__7945_8079 < count__7944_8078))
-{var vec__7946_8080 = cljs.core._nth.call(null,chunk__7943_8077,i__7945_8079);var ev__7760__auto___8081 = cljs.core.nth.call(null,vec__7946_8080,0,null);var func__7761__auto___8082 = cljs.core.nth.call(null,vec__7946_8080,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8081,func__7761__auto___8082);
+});})(e__6275__auto__))
+], null)));var chunk__6442_6576 = null;var count__6443_6577 = 0;var i__6444_6578 = 0;while(true){
+if((i__6444_6578 < count__6443_6577))
+{var vec__6445_6579 = cljs.core._nth.call(null,chunk__6442_6576,i__6444_6578);var ev__6276__auto___6580 = cljs.core.nth.call(null,vec__6445_6579,0,null);var func__6277__auto___6581 = cljs.core.nth.call(null,vec__6445_6579,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6580,func__6277__auto___6581);
 {
-var G__8083 = seq__7942_8076;
-var G__8084 = chunk__7943_8077;
-var G__8085 = count__7944_8078;
-var G__8086 = (i__7945_8079 + 1);
-seq__7942_8076 = G__8083;
-chunk__7943_8077 = G__8084;
-count__7944_8078 = G__8085;
-i__7945_8079 = G__8086;
+var G__6582 = seq__6441_6575;
+var G__6583 = chunk__6442_6576;
+var G__6584 = count__6443_6577;
+var G__6585 = (i__6444_6578 + 1);
+seq__6441_6575 = G__6582;
+chunk__6442_6576 = G__6583;
+count__6443_6577 = G__6584;
+i__6444_6578 = G__6585;
 continue;
 }
 } else
-{var temp__4092__auto___8087 = cljs.core.seq.call(null,seq__7942_8076);if(temp__4092__auto___8087)
-{var seq__7942_8088__$1 = temp__4092__auto___8087;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7942_8088__$1))
-{var c__7116__auto___8089 = cljs.core.chunk_first.call(null,seq__7942_8088__$1);{
-var G__8090 = cljs.core.chunk_rest.call(null,seq__7942_8088__$1);
-var G__8091 = c__7116__auto___8089;
-var G__8092 = cljs.core.count.call(null,c__7116__auto___8089);
-var G__8093 = 0;
-seq__7942_8076 = G__8090;
-chunk__7943_8077 = G__8091;
-count__7944_8078 = G__8092;
-i__7945_8079 = G__8093;
+{var temp__4092__auto___6586 = cljs.core.seq.call(null,seq__6441_6575);if(temp__4092__auto___6586)
+{var seq__6441_6587__$1 = temp__4092__auto___6586;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6441_6587__$1))
+{var c__5632__auto___6588 = cljs.core.chunk_first.call(null,seq__6441_6587__$1);{
+var G__6589 = cljs.core.chunk_rest.call(null,seq__6441_6587__$1);
+var G__6590 = c__5632__auto___6588;
+var G__6591 = cljs.core.count.call(null,c__5632__auto___6588);
+var G__6592 = 0;
+seq__6441_6575 = G__6589;
+chunk__6442_6576 = G__6590;
+count__6443_6577 = G__6591;
+i__6444_6578 = G__6592;
 continue;
 }
 } else
-{var vec__7947_8094 = cljs.core.first.call(null,seq__7942_8088__$1);var ev__7760__auto___8095 = cljs.core.nth.call(null,vec__7947_8094,0,null);var func__7761__auto___8096 = cljs.core.nth.call(null,vec__7947_8094,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8095,func__7761__auto___8096);
+{var vec__6446_6593 = cljs.core.first.call(null,seq__6441_6587__$1);var ev__6276__auto___6594 = cljs.core.nth.call(null,vec__6446_6593,0,null);var func__6277__auto___6595 = cljs.core.nth.call(null,vec__6446_6593,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6594,func__6277__auto___6595);
 {
-var G__8097 = cljs.core.next.call(null,seq__7942_8088__$1);
-var G__8098 = null;
-var G__8099 = 0;
-var G__8100 = 0;
-seq__7942_8076 = G__8097;
-chunk__7943_8077 = G__8098;
-count__7944_8078 = G__8099;
-i__7945_8079 = G__8100;
+var G__6596 = cljs.core.next.call(null,seq__6441_6587__$1);
+var G__6597 = null;
+var G__6598 = 0;
+var G__6599 = 0;
+seq__6441_6575 = G__6596;
+chunk__6442_6576 = G__6597;
+count__6443_6577 = G__6598;
+i__6444_6578 = G__6599;
 continue;
 }
 }
@@ -541,50 +545,50 @@ continue;
 }
 break;
 }
-return e__7759__auto__;
+return e__6275__auto__;
 });
-lt.plugins.litex.viewer.pdfimg = (function pdfimg(page,viewer){var e__7759__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"img","img",1014008629),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"class","class",1108647146),page], null)], null));var seq__7954_8101 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__7759__auto__){
+lt.plugins.litex.viewer.pdfimg = (function pdfimg(page,viewer){var e__6275__auto__ = crate.core.html.call(null,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"img","img",1014008629),new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"class","class",1108647146),page], null)], null));var seq__6453_6600 = cljs.core.seq.call(null,cljs.core.partition.call(null,2,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [new cljs.core.Keyword(null,"click","click",1108654330),((function (e__6275__auto__){
 return (function (event){return lt.object.raise.call(null,viewer,new cljs.core.Keyword(null,"image-click!","image-click!",4167726013),event);
-});})(e__7759__auto__))
-], null)));var chunk__7955_8102 = null;var count__7956_8103 = 0;var i__7957_8104 = 0;while(true){
-if((i__7957_8104 < count__7956_8103))
-{var vec__7958_8105 = cljs.core._nth.call(null,chunk__7955_8102,i__7957_8104);var ev__7760__auto___8106 = cljs.core.nth.call(null,vec__7958_8105,0,null);var func__7761__auto___8107 = cljs.core.nth.call(null,vec__7958_8105,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8106,func__7761__auto___8107);
+});})(e__6275__auto__))
+], null)));var chunk__6454_6601 = null;var count__6455_6602 = 0;var i__6456_6603 = 0;while(true){
+if((i__6456_6603 < count__6455_6602))
+{var vec__6457_6604 = cljs.core._nth.call(null,chunk__6454_6601,i__6456_6603);var ev__6276__auto___6605 = cljs.core.nth.call(null,vec__6457_6604,0,null);var func__6277__auto___6606 = cljs.core.nth.call(null,vec__6457_6604,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6605,func__6277__auto___6606);
 {
-var G__8108 = seq__7954_8101;
-var G__8109 = chunk__7955_8102;
-var G__8110 = count__7956_8103;
-var G__8111 = (i__7957_8104 + 1);
-seq__7954_8101 = G__8108;
-chunk__7955_8102 = G__8109;
-count__7956_8103 = G__8110;
-i__7957_8104 = G__8111;
+var G__6607 = seq__6453_6600;
+var G__6608 = chunk__6454_6601;
+var G__6609 = count__6455_6602;
+var G__6610 = (i__6456_6603 + 1);
+seq__6453_6600 = G__6607;
+chunk__6454_6601 = G__6608;
+count__6455_6602 = G__6609;
+i__6456_6603 = G__6610;
 continue;
 }
 } else
-{var temp__4092__auto___8112 = cljs.core.seq.call(null,seq__7954_8101);if(temp__4092__auto___8112)
-{var seq__7954_8113__$1 = temp__4092__auto___8112;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7954_8113__$1))
-{var c__7116__auto___8114 = cljs.core.chunk_first.call(null,seq__7954_8113__$1);{
-var G__8115 = cljs.core.chunk_rest.call(null,seq__7954_8113__$1);
-var G__8116 = c__7116__auto___8114;
-var G__8117 = cljs.core.count.call(null,c__7116__auto___8114);
-var G__8118 = 0;
-seq__7954_8101 = G__8115;
-chunk__7955_8102 = G__8116;
-count__7956_8103 = G__8117;
-i__7957_8104 = G__8118;
+{var temp__4092__auto___6611 = cljs.core.seq.call(null,seq__6453_6600);if(temp__4092__auto___6611)
+{var seq__6453_6612__$1 = temp__4092__auto___6611;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6453_6612__$1))
+{var c__5632__auto___6613 = cljs.core.chunk_first.call(null,seq__6453_6612__$1);{
+var G__6614 = cljs.core.chunk_rest.call(null,seq__6453_6612__$1);
+var G__6615 = c__5632__auto___6613;
+var G__6616 = cljs.core.count.call(null,c__5632__auto___6613);
+var G__6617 = 0;
+seq__6453_6600 = G__6614;
+chunk__6454_6601 = G__6615;
+count__6455_6602 = G__6616;
+i__6456_6603 = G__6617;
 continue;
 }
 } else
-{var vec__7959_8119 = cljs.core.first.call(null,seq__7954_8113__$1);var ev__7760__auto___8120 = cljs.core.nth.call(null,vec__7959_8119,0,null);var func__7761__auto___8121 = cljs.core.nth.call(null,vec__7959_8119,1,null);lt.util.dom.on.call(null,e__7759__auto__,ev__7760__auto___8120,func__7761__auto___8121);
+{var vec__6458_6618 = cljs.core.first.call(null,seq__6453_6612__$1);var ev__6276__auto___6619 = cljs.core.nth.call(null,vec__6458_6618,0,null);var func__6277__auto___6620 = cljs.core.nth.call(null,vec__6458_6618,1,null);lt.util.dom.on.call(null,e__6275__auto__,ev__6276__auto___6619,func__6277__auto___6620);
 {
-var G__8122 = cljs.core.next.call(null,seq__7954_8113__$1);
-var G__8123 = null;
-var G__8124 = 0;
-var G__8125 = 0;
-seq__7954_8101 = G__8122;
-chunk__7955_8102 = G__8123;
-count__7956_8103 = G__8124;
-i__7957_8104 = G__8125;
+var G__6621 = cljs.core.next.call(null,seq__6453_6612__$1);
+var G__6622 = null;
+var G__6623 = 0;
+var G__6624 = 0;
+seq__6453_6600 = G__6621;
+chunk__6454_6601 = G__6622;
+count__6455_6602 = G__6623;
+i__6456_6603 = G__6624;
 continue;
 }
 }
@@ -593,7 +597,7 @@ continue;
 }
 break;
 }
-return e__7759__auto__;
+return e__6275__auto__;
 });
 lt.plugins.litex.viewer.make_page = (function make_page(str,viewer){var re = (new RegExp("^Page *(\\d*) size: ([\\d\\.]*) x ([\\d\\.]*)"));var match = re.exec(str);if(cljs.core.truth_(match))
 {var page = parseInt((match[1]));var width = parseFloat((match[2]));var height = parseFloat((match[3]));return new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [page,new cljs.core.PersistentArrayMap(null, 5, [new cljs.core.Keyword(null,"page","page",1017337345),page,new cljs.core.Keyword(null,"width","width",1127031096),width,new cljs.core.Keyword(null,"height","height",4087841945),height,new cljs.core.Keyword(null,"img","img",1014008629),lt.plugins.litex.viewer.pdfimg.call(null,page,viewer),new cljs.core.Keyword(null,"zoom","zoom",1017648965),0], null)], null);
@@ -601,7 +605,7 @@ lt.plugins.litex.viewer.make_page = (function make_page(str,viewer){var re = (ne
 {return null;
 }
 });
-lt.plugins.litex.viewer.kwpairf = (function kwpairf(str){var vec__7961 = str.split(":");var k = cljs.core.nth.call(null,vec__7961,0,null);var v = cljs.core.nth.call(null,vec__7961,1,null);if(cljs.core.truth_(v))
+lt.plugins.litex.viewer.kwpairf = (function kwpairf(str){var vec__6460 = str.split(":");var k = cljs.core.nth.call(null,vec__6460,0,null);var v = cljs.core.nth.call(null,vec__6460,1,null);if(cljs.core.truth_(v))
 {return new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [cljs.core.keyword.call(null,k),parseFloat(v)], null);
 } else
 {return null;
@@ -612,11 +616,11 @@ lt.plugins.litex.viewer.connect_client = (function connect_client(this$){return 
 lt.plugins.litex.viewer.new_tabset = (function new_tabset(){var ts = lt.objs.tabs.spawn_tabset.call(null);lt.objs.tabs.equalize_tabset_widths.call(null);
 return ts;
 });
-lt.plugins.litex.viewer.add = (function add(){var viewer = lt.object.create.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","viewer","lt.plugins.litex.viewer/viewer",4117559032));var tabset = lt.objs.tabs.in_tab_QMARK_.call(null,lt.objs.editor.pool.last_active.call(null));var viewerts = (function (){var or__6368__auto__ = lt.objs.tabs.next_tabset.call(null,tabset);if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+lt.plugins.litex.viewer.add = (function add(){var viewer = lt.object.create.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","viewer","lt.plugins.litex.viewer/viewer",4117559032));var tabset = lt.objs.tabs.in_tab_QMARK_.call(null,lt.objs.editor.pool.last_active.call(null));var viewerts = (function (){var or__4884__auto__ = lt.objs.tabs.next_tabset.call(null,tabset);if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
-{var or__6368__auto____$1 = lt.objs.tabs.prev_tabset.call(null,tabset);if(cljs.core.truth_(or__6368__auto____$1))
-{return or__6368__auto____$1;
+{var or__4884__auto____$1 = lt.objs.tabs.prev_tabset.call(null,tabset);if(cljs.core.truth_(or__4884__auto____$1))
+{return or__4884__auto____$1;
 } else
 {return lt.plugins.litex.viewer.new_tabset.call(null);
 }
@@ -649,7 +653,7 @@ lt.plugins.litex.viewer.__BEH__layout_done = (function __BEH__layout_done(this$,
 } else
 {}
 var pdf_viewer = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#pdf-viewer","div#pdf-viewer",2086035953),lt.object.__GT_content.call(null,this$));var sync_box = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#sync-box","div#sync-box",2601350845),lt.object.__GT_content.call(null,this$));var scroll_top = pdf_viewer.scrollTop;var scroll_left = pdf_viewer.scrollLeft;var pages = cljs.core.into.call(null,cljs.core.PersistentArrayMap.EMPTY,cljs.core.remove.call(null,cljs.core.nil_QMARK_,cljs.core.map.call(null,((function (pdf_viewer,sync_box,scroll_top,scroll_left){
-return (function (p1__7962_SHARP_){return lt.plugins.litex.viewer.make_page.call(null,p1__7962_SHARP_,this$);
+return (function (p1__6461_SHARP_){return lt.plugins.litex.viewer.make_page.call(null,p1__6461_SHARP_,this$);
 });})(pdf_viewer,sync_box,scroll_top,scroll_left))
 ,stdout.split("\n"))));while(true){
 if(!(cljs.core._EQ_.call(null,sync_box,cljs.core.first.call(null,lt.util.dom.children.call(null,pdf_viewer)))))
@@ -661,45 +665,45 @@ continue;
 {}
 break;
 }
-var seq__7967_8126 = cljs.core.seq.call(null,cljs.core.sort.call(null,cljs.core.keys.call(null,pages)));var chunk__7968_8127 = null;var count__7969_8128 = 0;var i__7970_8129 = 0;while(true){
-if((i__7970_8129 < count__7969_8128))
-{var n_8130 = cljs.core._nth.call(null,chunk__7968_8127,i__7970_8129);lt.util.dom.before.call(null,sync_box,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(pages.call(null,n_8130)));
+var seq__6466_6625 = cljs.core.seq.call(null,cljs.core.sort.call(null,cljs.core.keys.call(null,pages)));var chunk__6467_6626 = null;var count__6468_6627 = 0;var i__6469_6628 = 0;while(true){
+if((i__6469_6628 < count__6468_6627))
+{var n_6629 = cljs.core._nth.call(null,chunk__6467_6626,i__6469_6628);lt.util.dom.before.call(null,sync_box,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(pages.call(null,n_6629)));
 {
-var G__8131 = seq__7967_8126;
-var G__8132 = chunk__7968_8127;
-var G__8133 = count__7969_8128;
-var G__8134 = (i__7970_8129 + 1);
-seq__7967_8126 = G__8131;
-chunk__7968_8127 = G__8132;
-count__7969_8128 = G__8133;
-i__7970_8129 = G__8134;
+var G__6630 = seq__6466_6625;
+var G__6631 = chunk__6467_6626;
+var G__6632 = count__6468_6627;
+var G__6633 = (i__6469_6628 + 1);
+seq__6466_6625 = G__6630;
+chunk__6467_6626 = G__6631;
+count__6468_6627 = G__6632;
+i__6469_6628 = G__6633;
 continue;
 }
 } else
-{var temp__4092__auto___8135 = cljs.core.seq.call(null,seq__7967_8126);if(temp__4092__auto___8135)
-{var seq__7967_8136__$1 = temp__4092__auto___8135;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7967_8136__$1))
-{var c__7116__auto___8137 = cljs.core.chunk_first.call(null,seq__7967_8136__$1);{
-var G__8138 = cljs.core.chunk_rest.call(null,seq__7967_8136__$1);
-var G__8139 = c__7116__auto___8137;
-var G__8140 = cljs.core.count.call(null,c__7116__auto___8137);
-var G__8141 = 0;
-seq__7967_8126 = G__8138;
-chunk__7968_8127 = G__8139;
-count__7969_8128 = G__8140;
-i__7970_8129 = G__8141;
+{var temp__4092__auto___6634 = cljs.core.seq.call(null,seq__6466_6625);if(temp__4092__auto___6634)
+{var seq__6466_6635__$1 = temp__4092__auto___6634;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6466_6635__$1))
+{var c__5632__auto___6636 = cljs.core.chunk_first.call(null,seq__6466_6635__$1);{
+var G__6637 = cljs.core.chunk_rest.call(null,seq__6466_6635__$1);
+var G__6638 = c__5632__auto___6636;
+var G__6639 = cljs.core.count.call(null,c__5632__auto___6636);
+var G__6640 = 0;
+seq__6466_6625 = G__6637;
+chunk__6467_6626 = G__6638;
+count__6468_6627 = G__6639;
+i__6469_6628 = G__6640;
 continue;
 }
 } else
-{var n_8142 = cljs.core.first.call(null,seq__7967_8136__$1);lt.util.dom.before.call(null,sync_box,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(pages.call(null,n_8142)));
+{var n_6641 = cljs.core.first.call(null,seq__6466_6635__$1);lt.util.dom.before.call(null,sync_box,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(pages.call(null,n_6641)));
 {
-var G__8143 = cljs.core.next.call(null,seq__7967_8136__$1);
-var G__8144 = null;
-var G__8145 = 0;
-var G__8146 = 0;
-seq__7967_8126 = G__8143;
-chunk__7968_8127 = G__8144;
-count__7969_8128 = G__8145;
-i__7970_8129 = G__8146;
+var G__6642 = cljs.core.next.call(null,seq__6466_6635__$1);
+var G__6643 = null;
+var G__6644 = 0;
+var G__6645 = 0;
+seq__6466_6625 = G__6642;
+chunk__6467_6626 = G__6643;
+count__6468_6627 = G__6644;
+i__6469_6628 = G__6645;
 continue;
 }
 }
@@ -731,7 +735,7 @@ lt.plugins.litex.viewer.__BEH__render_page = (function __BEH__render_page(this$)
 return (function (page){var img = new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(page);var imgtop = img.offsetTop;var imgbottom = (img.offsetHeight + imgtop);return ((imgbottom >= viewtop)) && ((imgtop <= viewbottom));
 });})(pdf_viewer,viewtop,viewbottom,pages))
 ,cljs.core.vals.call(null,pages));var zoom = new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$));var render_page = cljs.core.first.call(null,cljs.core.filter.call(null,((function (pdf_viewer,viewtop,viewbottom,pages,visible_pages,zoom){
-return (function (p1__7971_SHARP_){return (new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(p1__7971_SHARP_) < zoom);
+return (function (p1__6470_SHARP_){return (new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(p1__6470_SHARP_) < zoom);
 });})(pdf_viewer,viewtop,viewbottom,pages,visible_pages,zoom))
 ,cljs.core.concat.call(null,(new cljs.core.LazySeq(null,((function (pdf_viewer,viewtop,viewbottom,pages,visible_pages,zoom){
 return (function (){return visible_pages;
@@ -761,51 +765,51 @@ lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewe
 lt.plugins.litex.viewer.__BEH__zoom_out_BANG_ = (function __BEH__zoom_out_BANG_(this$){var zoom = new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$));var factor = new cljs.core.Keyword(null,"zoom-factor","zoom-factor",2715602939).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$));return lt.object.raise.call(null,this$,new cljs.core.Keyword(null,"set-zoom!","set-zoom!",520866037),(zoom / factor));
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","zoom-out!","lt.plugins.litex.viewer/zoom-out!",1172268339),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.viewer.__BEH__zoom_out_BANG_,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"zoom-out!","zoom-out!",2620430271),null], null), null));
-lt.plugins.litex.viewer.__BEH__set_zoom_BANG_ = (function __BEH__set_zoom_BANG_(this$,nzoom){var zoom = new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$));var pdf_viewer = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#pdf-viewer","div#pdf-viewer",2086035953),lt.object.__GT_content.call(null,this$));var vec__7978 = lt.plugins.litex.viewer.center_point.call(null,pdf_viewer);var x = cljs.core.nth.call(null,vec__7978,0,null);var y = cljs.core.nth.call(null,vec__7978,1,null);var new_zoom = (function (){var or__6368__auto__ = nzoom;if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+lt.plugins.litex.viewer.__BEH__set_zoom_BANG_ = (function __BEH__set_zoom_BANG_(this$,nzoom){var zoom = new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$));var pdf_viewer = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#pdf-viewer","div#pdf-viewer",2086035953),lt.object.__GT_content.call(null,this$));var vec__6477 = lt.plugins.litex.viewer.center_point.call(null,pdf_viewer);var x = cljs.core.nth.call(null,vec__6477,0,null);var y = cljs.core.nth.call(null,vec__6477,1,null);var new_zoom = (function (){var or__4884__auto__ = nzoom;if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
 {return zoom;
 }
 })();lt.object.merge_BANG_.call(null,this$,new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"zoom","zoom",1017648965),new_zoom], null));
-var seq__7979_8147 = cljs.core.seq.call(null,cljs.core.vals.call(null,new cljs.core.Keyword(null,"pages","pages",1120330550).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$))));var chunk__7980_8148 = null;var count__7981_8149 = 0;var i__7982_8150 = 0;while(true){
-if((i__7982_8150 < count__7981_8149))
-{var p_8151 = cljs.core._nth.call(null,chunk__7980_8148,i__7982_8150);lt.util.dom.css.call(null,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(p_8151),new cljs.core.PersistentArrayMap(null, 3, [new cljs.core.Keyword(null,"width","width",1127031096),Math.ceil((new cljs.core.Keyword(null,"width","width",1127031096).cljs$core$IFn$_invoke$arity$1(p_8151) * new_zoom)),new cljs.core.Keyword(null,"height","height",4087841945),Math.ceil((new cljs.core.Keyword(null,"height","height",4087841945).cljs$core$IFn$_invoke$arity$1(p_8151) * new_zoom)),new cljs.core.Keyword(null,"margin","margin",4227561760),[cljs.core.str((20 * new_zoom)),cljs.core.str("px auto")].join('')], null));
+var seq__6478_6646 = cljs.core.seq.call(null,cljs.core.vals.call(null,new cljs.core.Keyword(null,"pages","pages",1120330550).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$))));var chunk__6479_6647 = null;var count__6480_6648 = 0;var i__6481_6649 = 0;while(true){
+if((i__6481_6649 < count__6480_6648))
+{var p_6650 = cljs.core._nth.call(null,chunk__6479_6647,i__6481_6649);lt.util.dom.css.call(null,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(p_6650),new cljs.core.PersistentArrayMap(null, 3, [new cljs.core.Keyword(null,"width","width",1127031096),Math.ceil((new cljs.core.Keyword(null,"width","width",1127031096).cljs$core$IFn$_invoke$arity$1(p_6650) * new_zoom)),new cljs.core.Keyword(null,"height","height",4087841945),Math.ceil((new cljs.core.Keyword(null,"height","height",4087841945).cljs$core$IFn$_invoke$arity$1(p_6650) * new_zoom)),new cljs.core.Keyword(null,"margin","margin",4227561760),[cljs.core.str((20 * new_zoom)),cljs.core.str("px auto")].join('')], null));
 {
-var G__8152 = seq__7979_8147;
-var G__8153 = chunk__7980_8148;
-var G__8154 = count__7981_8149;
-var G__8155 = (i__7982_8150 + 1);
-seq__7979_8147 = G__8152;
-chunk__7980_8148 = G__8153;
-count__7981_8149 = G__8154;
-i__7982_8150 = G__8155;
+var G__6651 = seq__6478_6646;
+var G__6652 = chunk__6479_6647;
+var G__6653 = count__6480_6648;
+var G__6654 = (i__6481_6649 + 1);
+seq__6478_6646 = G__6651;
+chunk__6479_6647 = G__6652;
+count__6480_6648 = G__6653;
+i__6481_6649 = G__6654;
 continue;
 }
 } else
-{var temp__4092__auto___8156 = cljs.core.seq.call(null,seq__7979_8147);if(temp__4092__auto___8156)
-{var seq__7979_8157__$1 = temp__4092__auto___8156;if(cljs.core.chunked_seq_QMARK_.call(null,seq__7979_8157__$1))
-{var c__7116__auto___8158 = cljs.core.chunk_first.call(null,seq__7979_8157__$1);{
-var G__8159 = cljs.core.chunk_rest.call(null,seq__7979_8157__$1);
-var G__8160 = c__7116__auto___8158;
-var G__8161 = cljs.core.count.call(null,c__7116__auto___8158);
-var G__8162 = 0;
-seq__7979_8147 = G__8159;
-chunk__7980_8148 = G__8160;
-count__7981_8149 = G__8161;
-i__7982_8150 = G__8162;
+{var temp__4092__auto___6655 = cljs.core.seq.call(null,seq__6478_6646);if(temp__4092__auto___6655)
+{var seq__6478_6656__$1 = temp__4092__auto___6655;if(cljs.core.chunked_seq_QMARK_.call(null,seq__6478_6656__$1))
+{var c__5632__auto___6657 = cljs.core.chunk_first.call(null,seq__6478_6656__$1);{
+var G__6658 = cljs.core.chunk_rest.call(null,seq__6478_6656__$1);
+var G__6659 = c__5632__auto___6657;
+var G__6660 = cljs.core.count.call(null,c__5632__auto___6657);
+var G__6661 = 0;
+seq__6478_6646 = G__6658;
+chunk__6479_6647 = G__6659;
+count__6480_6648 = G__6660;
+i__6481_6649 = G__6661;
 continue;
 }
 } else
-{var p_8163 = cljs.core.first.call(null,seq__7979_8157__$1);lt.util.dom.css.call(null,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(p_8163),new cljs.core.PersistentArrayMap(null, 3, [new cljs.core.Keyword(null,"width","width",1127031096),Math.ceil((new cljs.core.Keyword(null,"width","width",1127031096).cljs$core$IFn$_invoke$arity$1(p_8163) * new_zoom)),new cljs.core.Keyword(null,"height","height",4087841945),Math.ceil((new cljs.core.Keyword(null,"height","height",4087841945).cljs$core$IFn$_invoke$arity$1(p_8163) * new_zoom)),new cljs.core.Keyword(null,"margin","margin",4227561760),[cljs.core.str((20 * new_zoom)),cljs.core.str("px auto")].join('')], null));
+{var p_6662 = cljs.core.first.call(null,seq__6478_6656__$1);lt.util.dom.css.call(null,new cljs.core.Keyword(null,"img","img",1014008629).cljs$core$IFn$_invoke$arity$1(p_6662),new cljs.core.PersistentArrayMap(null, 3, [new cljs.core.Keyword(null,"width","width",1127031096),Math.ceil((new cljs.core.Keyword(null,"width","width",1127031096).cljs$core$IFn$_invoke$arity$1(p_6662) * new_zoom)),new cljs.core.Keyword(null,"height","height",4087841945),Math.ceil((new cljs.core.Keyword(null,"height","height",4087841945).cljs$core$IFn$_invoke$arity$1(p_6662) * new_zoom)),new cljs.core.Keyword(null,"margin","margin",4227561760),[cljs.core.str((20 * new_zoom)),cljs.core.str("px auto")].join('')], null));
 {
-var G__8164 = cljs.core.next.call(null,seq__7979_8157__$1);
-var G__8165 = null;
-var G__8166 = 0;
-var G__8167 = 0;
-seq__7979_8147 = G__8164;
-chunk__7980_8148 = G__8165;
-count__7981_8149 = G__8166;
-i__7982_8150 = G__8167;
+var G__6663 = cljs.core.next.call(null,seq__6478_6656__$1);
+var G__6664 = null;
+var G__6665 = 0;
+var G__6666 = 0;
+seq__6478_6646 = G__6663;
+chunk__6479_6647 = G__6664;
+count__6480_6648 = G__6665;
+i__6481_6649 = G__6666;
 continue;
 }
 }
@@ -814,15 +818,15 @@ continue;
 }
 break;
 }
-return lt.plugins.litex.viewer.set_center_point.call(null,pdf_viewer,cljs.core.map.call(null,((function (zoom,pdf_viewer,vec__7978,x,y,new_zoom){
-return (function (p1__7972_SHARP_){return (p1__7972_SHARP_ * (new_zoom / zoom));
-});})(zoom,pdf_viewer,vec__7978,x,y,new_zoom))
+return lt.plugins.litex.viewer.set_center_point.call(null,pdf_viewer,cljs.core.map.call(null,((function (zoom,pdf_viewer,vec__6477,x,y,new_zoom){
+return (function (p1__6471_SHARP_){return (p1__6471_SHARP_ * (new_zoom / zoom));
+});})(zoom,pdf_viewer,vec__6477,x,y,new_zoom))
 ,new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [x,y], null)));
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","set-zoom!","lt.plugins.litex.viewer/set-zoom!",3334100069),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.viewer.__BEH__set_zoom_BANG_,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"set-zoom!","set-zoom!",520866037),null], null), null));
 lt.plugins.litex.viewer.center_point = (function center_point(elem){return new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [(elem.scrollLeft + (elem.clientWidth / 2)),(elem.scrollTop + (elem.clientHeight / 2))], null);
 });
-lt.plugins.litex.viewer.set_center_point = (function set_center_point(elem,p__7983){var vec__7985 = p__7983;var x = cljs.core.nth.call(null,vec__7985,0,null);var y = cljs.core.nth.call(null,vec__7985,1,null);elem.scrollLeft = (x - (elem.clientWidth / 2));
+lt.plugins.litex.viewer.set_center_point = (function set_center_point(elem,p__6482){var vec__6484 = p__6482;var x = cljs.core.nth.call(null,vec__6484,0,null);var y = cljs.core.nth.call(null,vec__6484,1,null);elem.scrollLeft = (x - (elem.clientWidth / 2));
 return elem.scrollTop = (y - (elem.clientHeight / 2));
 });
 lt.plugins.litex.viewer.__BEH__show_log_BANG_ = (function __BEH__show_log_BANG_(this$){return lt.util.dom.remove_class.call(null,lt.object.__GT_content.call(null,this$),"hide-log");
@@ -831,13 +835,13 @@ lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewe
 lt.plugins.litex.viewer.__BEH__hide_log_BANG_ = (function __BEH__hide_log_BANG_(this$){return lt.util.dom.add_class.call(null,lt.object.__GT_content.call(null,this$),"hide-log");
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","hide-log!","lt.plugins.litex.viewer/hide-log!",2486896090),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.viewer.__BEH__hide_log_BANG_,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"hide-log!","hide-log!",1821177466),null], null), null));
-lt.plugins.litex.viewer.__BEH__image_click_BANG_ = (function __BEH__image_click_BANG_(this$,event){if(cljs.core.truth_((function (){var or__6368__auto__ = event.ctrlKey;if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+lt.plugins.litex.viewer.__BEH__image_click_BANG_ = (function __BEH__image_click_BANG_(this$,event){if(cljs.core.truth_((function (){var or__4884__auto__ = event.ctrlKey;if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
-{var and__6356__auto__ = lt.objs.platform.mac_QMARK_.call(null);if(cljs.core.truth_(and__6356__auto__))
+{var and__4872__auto__ = lt.objs.platform.mac_QMARK_.call(null);if(cljs.core.truth_(and__4872__auto__))
 {return event.metaKey;
 } else
-{return and__6356__auto__;
+{return and__4872__auto__;
 }
 }
 })()))
@@ -847,10 +851,10 @@ lt.plugins.litex.viewer.__BEH__image_click_BANG_ = (function __BEH__image_click_
 }
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","image-click!","lt.plugins.litex.viewer/image-click!",3767830813),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.viewer.__BEH__image_click_BANG_,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"image-click!","image-click!",4167726013),null], null), null));
-lt.plugins.litex.viewer.__BEH__mouse_wheel_BANG_ = (function __BEH__mouse_wheel_BANG_(this$,event){if(cljs.core.truth_((function (){var and__6356__auto__ = event.altKey;if(cljs.core.truth_(and__6356__auto__))
+lt.plugins.litex.viewer.__BEH__mouse_wheel_BANG_ = (function __BEH__mouse_wheel_BANG_(this$,event){if(cljs.core.truth_((function (){var and__4872__auto__ = event.altKey;if(cljs.core.truth_(and__4872__auto__))
 {return (cljs.core.not.call(null,event.shiftKey)) && (cljs.core.not_EQ_.call(null,event.wheelDeltaY,0));
 } else
-{return and__6356__auto__;
+{return and__4872__auto__;
 }
 })()))
 {event.preventDefault();
@@ -903,30 +907,30 @@ lt.plugins.litex.viewer.__BEH__forward_sync = (function __BEH__forward_sync(this
 if(cljs.core.truth_(new cljs.core.Keyword(null,"laying-out","laying-out",4406897713).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,viewer))))
 {return lt.object.merge_BANG_.call(null,viewer,new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"sync-msg","sync-msg",2829477057),msg], null));
 } else
-{var data = new cljs.core.Keyword(null,"data","data",1016980252).cljs$core$IFn$_invoke$arity$1(msg);var pdf_viewer = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#pdf-viewer","div#pdf-viewer",2086035953),lt.object.__GT_content.call(null,viewer));var sync_box = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#sync-box","div#sync-box",2601350845),lt.object.__GT_content.call(null,viewer));var output_split = (function (){var and__6356__auto__ = new cljs.core.Keyword(null,"stdout","stdout",4416474557).cljs$core$IFn$_invoke$arity$1(data);if(cljs.core.truth_(and__6356__auto__))
+{var data = new cljs.core.Keyword(null,"data","data",1016980252).cljs$core$IFn$_invoke$arity$1(msg);var pdf_viewer = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#pdf-viewer","div#pdf-viewer",2086035953),lt.object.__GT_content.call(null,viewer));var sync_box = lt.util.dom.$.call(null,new cljs.core.Keyword(null,"div#sync-box","div#sync-box",2601350845),lt.object.__GT_content.call(null,viewer));var output_split = (function (){var and__4872__auto__ = new cljs.core.Keyword(null,"stdout","stdout",4416474557).cljs$core$IFn$_invoke$arity$1(data);if(cljs.core.truth_(and__4872__auto__))
 {return cljs.core.rest.call(null,new cljs.core.Keyword(null,"stdout","stdout",4416474557).cljs$core$IFn$_invoke$arity$1(data).split("\nOutput"));
 } else
-{return and__6356__auto__;
+{return and__4872__auto__;
 }
 })();var restore_top = new cljs.core.Keyword(null,"restore-top","restore-top",1342702856).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,viewer));var restore_left = new cljs.core.Keyword(null,"restore-left","restore-left",2616478552).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,viewer));lt.object.merge_BANG_.call(null,viewer,new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"restore-top","restore-top",1342702856),null,new cljs.core.Keyword(null,"restore-left","restore-left",2616478552),null], null));
 pdf_viewer.offsetHeight = pdf_viewer.offsetHeight;
 if(cljs.core.truth_(output_split))
 {var zoom = new cljs.core.Keyword(null,"zoom","zoom",1017648965).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,new cljs.core.Keyword(null,"frame","frame",1111596255).cljs$core$IFn$_invoke$arity$1(cljs.core.deref.call(null,this$))));var locs = cljs.core.map.call(null,((function (zoom,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname){
-return (function (p1__7986_SHARP_){return lt.plugins.litex.viewer.pdf_to_elem.call(null,pdf_viewer,zoom,cljs.core.into.call(null,cljs.core.PersistentArrayMap.EMPTY,cljs.core.remove.call(null,cljs.core.nil_QMARK_,cljs.core.map.call(null,lt.plugins.litex.viewer.kwpairf,p1__7986_SHARP_.split("\n")))));
+return (function (p1__6485_SHARP_){return lt.plugins.litex.viewer.pdf_to_elem.call(null,pdf_viewer,zoom,cljs.core.into.call(null,cljs.core.PersistentArrayMap.EMPTY,cljs.core.remove.call(null,cljs.core.nil_QMARK_,cljs.core.map.call(null,lt.plugins.litex.viewer.kwpairf,p1__6485_SHARP_.split("\n")))));
 });})(zoom,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname))
 ,output_split);var bbleft = cljs.core.apply.call(null,cljs.core.min,cljs.core.map.call(null,new cljs.core.Keyword(null,"h","h",1013904346),locs));var bbtop = cljs.core.apply.call(null,cljs.core.min,cljs.core.map.call(null,((function (zoom,locs,bbleft,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname){
-return (function (p1__7987_SHARP_){return (new cljs.core.Keyword(null,"v","v",1013904360).cljs$core$IFn$_invoke$arity$1(p1__7987_SHARP_) - new cljs.core.Keyword(null,"H","H",1013904314).cljs$core$IFn$_invoke$arity$1(p1__7987_SHARP_));
+return (function (p1__6486_SHARP_){return (new cljs.core.Keyword(null,"v","v",1013904360).cljs$core$IFn$_invoke$arity$1(p1__6486_SHARP_) - new cljs.core.Keyword(null,"H","H",1013904314).cljs$core$IFn$_invoke$arity$1(p1__6486_SHARP_));
 });})(zoom,locs,bbleft,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname))
 ,locs));var bbright = cljs.core.apply.call(null,cljs.core.max,cljs.core.map.call(null,((function (zoom,locs,bbleft,bbtop,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname){
-return (function (p1__7988_SHARP_){return (new cljs.core.Keyword(null,"h","h",1013904346).cljs$core$IFn$_invoke$arity$1(p1__7988_SHARP_) + new cljs.core.Keyword(null,"W","W",1013904329).cljs$core$IFn$_invoke$arity$1(p1__7988_SHARP_));
+return (function (p1__6487_SHARP_){return (new cljs.core.Keyword(null,"h","h",1013904346).cljs$core$IFn$_invoke$arity$1(p1__6487_SHARP_) + new cljs.core.Keyword(null,"W","W",1013904329).cljs$core$IFn$_invoke$arity$1(p1__6487_SHARP_));
 });})(zoom,locs,bbleft,bbtop,data,pdf_viewer,sync_box,output_split,restore_top,restore_left,viewer,pdfname))
-,locs));var bbbottom = cljs.core.apply.call(null,cljs.core.max,cljs.core.map.call(null,new cljs.core.Keyword(null,"v","v",1013904360),locs));var bbwidth = (bbright - bbleft);var bbheight = (bbbottom - bbtop);var vleft = (function (){var or__6368__auto__ = restore_left;if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+,locs));var bbbottom = cljs.core.apply.call(null,cljs.core.max,cljs.core.map.call(null,new cljs.core.Keyword(null,"v","v",1013904360),locs));var bbwidth = (bbright - bbleft);var bbheight = (bbbottom - bbtop);var vleft = (function (){var or__4884__auto__ = restore_left;if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
 {return pdf_viewer.scrollLeft;
 }
-})();var vwidth = pdf_viewer.clientWidth;var vright = (vleft + vwidth);var vtop = (function (){var or__6368__auto__ = restore_top;if(cljs.core.truth_(or__6368__auto__))
-{return or__6368__auto__;
+})();var vwidth = pdf_viewer.clientWidth;var vright = (vleft + vwidth);var vtop = (function (){var or__4884__auto__ = restore_top;if(cljs.core.truth_(or__4884__auto__))
+{return or__4884__auto__;
 } else
 {return pdf_viewer.scrollTop;
 }
@@ -941,7 +945,7 @@ return lt.util.dom.add_class.call(null,sync_box,new cljs.core.Keyword(null,"anim
 }
 });
 lt.object.behavior_STAR_.call(null,new cljs.core.Keyword("lt.plugins.litex.viewer","forward-sync","lt.plugins.litex.viewer/forward-sync",3501952325),new cljs.core.Keyword(null,"reaction","reaction",4441361819),lt.plugins.litex.viewer.__BEH__forward_sync,new cljs.core.Keyword(null,"triggers","triggers",2516997421),new cljs.core.PersistentHashSet(null, new cljs.core.PersistentArrayMap(null, 1, [new cljs.core.Keyword(null,"litex.forward-sync!","litex.forward-sync!",2282754540),null], null), null));
-lt.plugins.litex.viewer.pdf_to_elem = (function pdf_to_elem(elem,zoom,loc){var map__7990 = loc;var map__7990__$1 = ((cljs.core.seq_QMARK_.call(null,map__7990))?cljs.core.apply.call(null,cljs.core.hash_map,map__7990):map__7990);var Page = cljs.core.get.call(null,map__7990__$1,new cljs.core.Keyword(null,"Page","Page",1016384033));var H = cljs.core.get.call(null,map__7990__$1,new cljs.core.Keyword(null,"H","H",1013904314));var W = cljs.core.get.call(null,map__7990__$1,new cljs.core.Keyword(null,"W","W",1013904329));var v = cljs.core.get.call(null,map__7990__$1,new cljs.core.Keyword(null,"v","v",1013904360));var h = cljs.core.get.call(null,map__7990__$1,new cljs.core.Keyword(null,"h","h",1013904346));var img = cljs.core.nth.call(null,lt.util.dom.children.call(null,elem),(Page - 1));if((cljs.core.not.call(null,img)) || (cljs.core._EQ_.call(null,img.id,"sync-box")))
+lt.plugins.litex.viewer.pdf_to_elem = (function pdf_to_elem(elem,zoom,loc){var map__6489 = loc;var map__6489__$1 = ((cljs.core.seq_QMARK_.call(null,map__6489))?cljs.core.apply.call(null,cljs.core.hash_map,map__6489):map__6489);var Page = cljs.core.get.call(null,map__6489__$1,new cljs.core.Keyword(null,"Page","Page",1016384033));var H = cljs.core.get.call(null,map__6489__$1,new cljs.core.Keyword(null,"H","H",1013904314));var W = cljs.core.get.call(null,map__6489__$1,new cljs.core.Keyword(null,"W","W",1013904329));var v = cljs.core.get.call(null,map__6489__$1,new cljs.core.Keyword(null,"v","v",1013904360));var h = cljs.core.get.call(null,map__6489__$1,new cljs.core.Keyword(null,"h","h",1013904346));var img = cljs.core.nth.call(null,lt.util.dom.children.call(null,elem),(Page - 1));if((cljs.core.not.call(null,img)) || (cljs.core._EQ_.call(null,img.id,"sync-box")))
 {throw [cljs.core.str("Error: could not find image for page "),cljs.core.str(Page)].join('');
 } else
 {}

--- a/src/lt/plugins/litex.cljs
+++ b/src/lt/plugins/litex.cljs
@@ -101,13 +101,14 @@
     (run-commands commands cwd exitfunc)))
 
 (defn load-settings [path]
-  (let [file (files/open-sync path)
-        content (:content file)]
-    (if content
-      (try
-        (js->clj (js/JSON.parse (.replace content (js/RegExp. "^\\s*//.*$" "gm") "")))
-        (catch js/Error e
-          (js/console.log (str "Error parsing " path ":\n  " e "\nIgnoring this file.")))))))
+  (if (files/file? path)
+    (let [file (files/open-sync path)
+          content (:content file)]
+      (if content
+        (try
+          (js->clj (js/JSON.parse (.replace content (js/RegExp. "^\\s*//.*$" "gm") "")))
+          (catch js/Error e
+            (js/console.log (str "Error parsing " path ":\n  " e "\nIgnoring this file."))))))))
 
 (defn global-settings []
   (files/join (files/parent files/data-path) "litexrc"))


### PR DESCRIPTION
Thanks for this great plugin. However after installation I was constantly having troubles with errors of the type ENOENT "Could not find file /path/to/local/config/litexrc and /path/to/latexfile/.litexrc". Of course creating those files would resolve the problem but why bothering when the plugin works out of the box ?

Solution:
I just added a line for testing the existence of these files before opening them in the function `load-settings` and used the `files/file?` LT function for that purpose.
